### PR TITLE
feat(runtime): expose mutable accessors for core and registry

### DIFF
--- a/extras/src/runtime/mod.rs
+++ b/extras/src/runtime/mod.rs
@@ -91,8 +91,16 @@ impl HypertileRuntime {
         &self.core
     }
 
+    pub fn core_mut(&mut self) -> &mut CoreHypertile {
+        &mut self.core
+    }
+
     pub fn registry(&self) -> &Registry {
         &self.registry
+    }
+
+    pub fn registry_mut(&mut self) -> &mut Registry {
+        &mut self.registry
     }
 
     pub fn mode(&self) -> InputMode {

--- a/extras/src/runtime/mod.rs
+++ b/extras/src/runtime/mod.rs
@@ -91,6 +91,10 @@ impl HypertileRuntime {
         &self.core
     }
 
+    /// Mutating the core directly can leave the runtime's plugin registry
+    /// and animation state out of sync. Prefer using runtime methods
+    /// [`Self::split_focused`], [`Self::close_focused`], and
+    /// [`Self::replace_pane_plugin`] when possible.
     pub fn core_mut(&mut self) -> &mut CoreHypertile {
         &mut self.core
     }
@@ -98,7 +102,11 @@ impl HypertileRuntime {
     pub fn registry(&self) -> &Registry {
         &self.registry
     }
-
+    
+    /// Mutating the registry directly can leave it out of
+    /// sync with the core pane tree. Prefer runtime methods
+    /// [`Self::register_plugin_type`], [`Self::split_focused`], and
+    /// [`Self::replace_pane_plugin`] when possible.
     pub fn registry_mut(&mut self) -> &mut Registry {
         &mut self.registry
     }


### PR DESCRIPTION
Add core_mut() and registry_mut() methods to HypertileRuntime, enabling external HypertileWidget implementations to mutate state.

Can you cut a minor version if accepted ?