### PR TITLE
feat(extras): take mutable self in HypertilePlugin::render

### DIFF
--- a/extras/examples/basic.rs
+++ b/extras/examples/basic.rs
@@ -153,7 +153,7 @@ struct MonitorPlugin {
 }
 
 impl HypertilePlugin for MonitorPlugin {
-    fn render(&self, area: Rect, buf: &mut Buffer, is_focused: bool) {
+    fn render(&mut self, area: Rect, buf: &mut Buffer, is_focused: bool) {
         let mut lines = vec![Line::from("")];
         for (i, &usage) in self.cpu.iter().enumerate() {
             let filled = usage as usize * 20 / 100;
@@ -217,7 +217,7 @@ struct LogsPlugin {
 }
 
 impl HypertilePlugin for LogsPlugin {
-    fn render(&self, area: Rect, buf: &mut Buffer, is_focused: bool) {
+    fn render(&mut self, area: Rect, buf: &mut Buffer, is_focused: bool) {
         let text: Vec<Line> = self
             .lines
             .iter()
@@ -252,7 +252,7 @@ struct EditorPlugin {
 }
 
 impl HypertilePlugin for EditorPlugin {
-    fn render(&self, area: Rect, buf: &mut Buffer, is_focused: bool) {
+    fn render(&mut self, area: Rect, buf: &mut Buffer, is_focused: bool) {
         Paragraph::new(format!("{}\u{2588}", self.text))
             .block(pane_block("Editor", is_focused, Color::Magenta))
             .wrap(Wrap { trim: false })
@@ -286,7 +286,7 @@ struct NetworkPlugin {
 }
 
 impl HypertilePlugin for NetworkPlugin {
-    fn render(&self, area: Rect, buf: &mut Buffer, is_focused: bool) {
+    fn render(&mut self, area: Rect, buf: &mut Buffer, is_focused: bool) {
         let t = self.tick;
         let conns = 800 + (t * 17 % 120) as u32;
         let rps = 1100 + (t * 31 % 400) as u32;

--- a/extras/src/registry.rs
+++ b/extras/src/registry.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Trait implemented by pane-local plugins stored in [`Registry`].
 pub trait HypertilePlugin {
-    fn render(&self, area: Rect, buf: &mut Buffer, is_focused: bool);
+    fn render(&mut self, area: Rect, buf: &mut Buffer, is_focused: bool);
 
     /// Return [`EventOutcome::Consumed`] to mark it handled.
     fn on_event(&mut self, _event: &HypertileEvent) -> EventOutcome {

--- a/extras/src/runtime/default_plugin.rs
+++ b/extras/src/runtime/default_plugin.rs
@@ -20,7 +20,7 @@ impl DefaultBlockPlugin {
 }
 
 impl HypertilePlugin for DefaultBlockPlugin {
-    fn render(&self, area: Rect, buf: &mut Buffer, is_focused: bool) {
+    fn render(&mut self, area: Rect, buf: &mut Buffer, is_focused: bool) {
         let mut block = Block::default()
             .borders(Borders::ALL)
             .title(self.title.as_str());

--- a/extras/src/runtime/palette.rs
+++ b/extras/src/runtime/palette.rs
@@ -282,7 +282,7 @@ mod tests {
 
     struct Dummy;
     impl HypertilePlugin for Dummy {
-        fn render(&self, _area: Rect, _buf: &mut Buffer, _is_focused: bool) {}
+        fn render(&mut self, _area: Rect, _buf: &mut Buffer, _is_focused: bool) {}
     }
 
     #[test]

--- a/extras/src/runtime/render.rs
+++ b/extras/src/runtime/render.rs
@@ -19,7 +19,7 @@ impl HypertileRuntime {
         self.core.compute_layout(area);
         let focused = self.core.focused_pane();
         let highlight = self.core.state().focus_highlight();
-        let registry = &self.registry;
+        let registry = &mut self.registry;
         let border_config = &self.border_config;
         let panes = self
             .animation_state
@@ -27,7 +27,7 @@ impl HypertileRuntime {
 
         for &(pane_id, rect) in panes {
             let is_focused = highlight && Some(pane_id) == focused;
-            if let Some(plugin) = registry.plugin(pane_id) {
+            if let Some(plugin) = registry.plugin_mut(pane_id) {
                 plugin.render(rect, buf, is_focused);
             } else {
                 render_fallback_pane(border_config, pane_id, rect, buf, is_focused);


### PR DESCRIPTION
Change render signature from immutable to mutable self reference to support stateful widgets requiring mutable access during plugin rendering.

Fixes: https://github.com/nikolic-milos/ratatui-hypertile/issues/4