### PR TITLE
feat(extras): a unique id for each tab

### DIFF
--- a/extras/src/lib.rs
+++ b/extras/src/lib.rs
@@ -19,7 +19,7 @@ mod runtime;
 pub use registry::{HypertilePlugin, PluginContext, Registry, RegistryError};
 pub use runtime::{
     AnimationConfig, BorderConfig, HypertileRuntime, HypertileRuntimeBuilder, HypertileView,
-    InputMode, ModeIndicator, MoveBindings, RuntimeError, SplitBehavior, TabBar, TabBarItem,
+    InputMode, ModeIndicator, MoveBindings, RuntimeError, SplitBehavior, TabBar, TabBarItem, TabId,
     WorkspaceAction, WorkspaceRuntime,
 };
 

--- a/extras/src/runtime/mod.rs
+++ b/extras/src/runtime/mod.rs
@@ -33,7 +33,7 @@ pub use keymap::MoveBindings;
 pub use tab_bar::{TabBar, TabBarItem};
 pub use types::{AnimationConfig, BorderConfig, InputMode, RuntimeError, SplitBehavior};
 pub use widget::{HypertileView, ModeIndicator};
-pub use workspace::{WorkspaceAction, WorkspaceRuntime};
+pub use workspace::{TabId, WorkspaceAction, WorkspaceRuntime};
 
 use animation::AnimationState;
 use constants::DEFAULT_PLUGIN_TYPE;

--- a/extras/src/runtime/workspace.rs
+++ b/extras/src/runtime/workspace.rs
@@ -4,8 +4,13 @@ use std::time::Duration;
 
 use super::HypertileRuntime;
 
+/// Represents a tab in the application.
 struct Tab {
+    /// Unique identifier.
+    tab_id: usize,
+    /// Display text shown in the tab header.
     label: String,
+    /// Execution environment for the tab's content.
     runtime: HypertileRuntime,
 }
 
@@ -15,8 +20,14 @@ struct Tab {
 /// workspace model without building it yourself. It intercepts a few `Ctrl+...`
 /// keys for tab management and forwards everything else to the active tab.
 pub struct WorkspaceRuntime {
+    /// Manages the collection of open tabs in the workspace.
     tabs: Vec<Tab>,
+    /// Index of the currently focused tab.
     active: usize,
+    /// Monotonically increasing source of unique identifiers for tabs. Never
+    /// decrements, even when tabs are closed.
+    tabs_ids: usize,
+    /// Produces new tab runtimes on demand.
     factory: Box<dyn Fn() -> HypertileRuntime>,
 }
 
@@ -48,8 +59,10 @@ impl WorkspaceRuntime {
             tabs: vec![Tab {
                 label: "1".to_string(),
                 runtime: first,
+                tab_id: 0,
             }],
             active: 0,
+            tabs_ids: 1,
             factory: Box::new(factory),
         }
     }
@@ -75,6 +88,10 @@ impl WorkspaceRuntime {
         self.active
     }
 
+    pub fn active_tab_id(&self) -> usize {
+        self.tabs[self.active].tab_id
+    }
+
     pub fn tab_labels(&self) -> impl Iterator<Item = (&str, bool)> {
         self.tabs
             .iter()
@@ -86,7 +103,12 @@ impl WorkspaceRuntime {
     pub fn new_tab(&mut self) {
         let label = (self.tabs.len() + 1).to_string();
         let runtime = (self.factory)();
-        self.tabs.push(Tab { label, runtime });
+        self.tabs.push(Tab {
+            label,
+            runtime,
+            tab_id: self.tabs_ids,
+        });
+        self.tabs_ids += 1;
         self.active = self.tabs.len() - 1;
     }
 

--- a/extras/src/runtime/workspace.rs
+++ b/extras/src/runtime/workspace.rs
@@ -4,10 +4,21 @@ use std::time::Duration;
 
 use super::HypertileRuntime;
 
+/// Uniquely identifies a tab
+#[derive(Clone, Copy)]
+pub struct TabId(usize);
+
+impl TabId {
+    /// Extracts the underlying primitive value from the identifier
+    pub const fn get(&self) -> usize {
+        self.0
+    }
+}
+
 /// Represents a tab in the application.
 struct Tab {
     /// Unique identifier.
-    tab_id: usize,
+    tab_id: TabId,
     /// Display text shown in the tab header.
     label: String,
     /// Execution environment for the tab's content.
@@ -26,7 +37,7 @@ pub struct WorkspaceRuntime {
     active: usize,
     /// Monotonically increasing source of unique identifiers for tabs. Never
     /// decrements, even when tabs are closed.
-    tabs_ids: usize,
+    next_tab_id: usize,
     /// Produces new tab runtimes on demand.
     factory: Box<dyn Fn() -> HypertileRuntime>,
 }
@@ -54,15 +65,20 @@ impl WorkspaceRuntime {
     /// The factory is reused for every new tab, so it should return a fully
     /// configured runtime with your plugin registrations already in place.
     pub fn new(factory: impl Fn() -> HypertileRuntime + 'static) -> Self {
+        /// Default initial tab when the application starts
+        const FIRST_TAB: TabId = TabId(0);
+        /// Starting index for dynamically created tabs after the default tab
+        const FIRST_NEXT_ID: usize = FIRST_TAB.0 + 1;
+
         let first = factory();
         Self {
             tabs: vec![Tab {
                 label: "1".to_string(),
                 runtime: first,
-                tab_id: 0,
+                tab_id: FIRST_TAB,
             }],
             active: 0,
-            tabs_ids: 1,
+            next_tab_id: FIRST_NEXT_ID,
             factory: Box::new(factory),
         }
     }
@@ -88,7 +104,8 @@ impl WorkspaceRuntime {
         self.active
     }
 
-    pub fn active_tab_id(&self) -> usize {
+    /// Returns the active tab id
+    pub fn active_tab_id(&self) -> TabId {
         self.tabs[self.active].tab_id
     }
 
@@ -106,9 +123,9 @@ impl WorkspaceRuntime {
         self.tabs.push(Tab {
             label,
             runtime,
-            tab_id: self.tabs_ids,
+            tab_id: TabId(self.next_tab_id),
         });
-        self.tabs_ids += 1;
+        self.next_tab_id += 1;
         self.active = self.tabs.len() - 1;
     }
 

--- a/extras/src/runtime/workspace.rs
+++ b/extras/src/runtime/workspace.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use super::HypertileRuntime;
 
 /// Uniquely identifies a tab
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct TabId(usize);
 
 impl TabId {
@@ -107,6 +107,18 @@ impl WorkspaceRuntime {
     /// Returns the active tab id
     pub fn active_tab_id(&self) -> TabId {
         self.tabs[self.active].tab_id
+    }
+
+    /// Returns an iterator over the identifiers of all currently open tabs
+    pub fn open_tab_ids(&self) -> impl Iterator<Item = TabId> {
+        self.tabs.iter().map(|t| t.tab_id)
+    }
+
+    /// Returns `true` if the given tab id is open
+    ///
+    /// To check if it's the active tab, use [`WorkspaceRuntime::active_tab_id`]
+    pub fn is_tab_open(&self, tab_id: TabId) -> bool {
+        self.tabs.iter().any(|t| t.tab_id == tab_id)
     }
 
     pub fn tab_labels(&self) -> impl Iterator<Item = (&str, bool)> {


### PR DESCRIPTION
Add a unique ID assignment system for tabs using a simple counter in the workspace. Each new tab receives a guaranteed unique identifier that persists for the tab's lifetime.

This enables per-tab state management, such as tracking toasts or notifications that are specific to individual tabs rather than shared globally.